### PR TITLE
Fix Maytoni track length boundary condition for Maytoni

### DIFF
--- a/maytoni.js
+++ b/maytoni.js
@@ -72,7 +72,7 @@
   function getTracks(len, opts) {
     let pieces=[];
     opts.forEach(o=>{
-      if(len>o.min&&len<=o.max) pieces.push({id:o.items[0],pieceLength:o.max});
+      if(len>=o.min&&len<=o.max) pieces.push({id:o.items[0],pieceLength:o.max});
     });
     if(pieces.length===0&&len>opts[opts.length-1].max) {
       const max=opts[opts.length-1];


### PR DESCRIPTION
## Summary
- ensure the Maytoni UNITY track picker handles length boundaries inclusively so 101/201 cm selections resolve to the correct segment

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ef7867617c8329bcbe9a111b4ccb24